### PR TITLE
feat: Add d flag to return screen number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+lsm
+lsm.o
+mattr
+mattr.o
+pfm
+pfm.o
+util.o
+

--- a/mattr.1
+++ b/mattr.1
@@ -8,7 +8,7 @@
 .Nm mattr
 .Op Fl h
 .Op Fl c
-.Op Cm inwhxys
+.Op Cm inwhxyds
 .Ar wid|mid
 .Sh DESCRIPTION
 .Nm
@@ -27,7 +27,7 @@ Print
 .Ar mid Ns .
 .It Cm i
 Print
-.Ar mid Ns \ (wmutils compat).
+.Ar mid Ns \ (wmutils compat) (DEPRECATED).
 .It Cm w
 Print
 .Ar mid Ns \(cqs width.
@@ -57,6 +57,11 @@ passed as an argument. Useful only when
 .Ar wid
 is passed. Otherwise equivalent to 
 .Ar n Ns .
+.It Cm d
+Print
+.Ar mid Ns \(cqs
+.EN
+Xorg screen number
 .sp
 .Sh SEE ALSO
 .sp

--- a/mattr.c
+++ b/mattr.c
@@ -11,7 +11,7 @@ static xcb_connection_t *conn;
 
 static void
 usage(char *name) {
-    fprintf(stderr, "usage: %s [-h] [-c] [nwhxyd] <wid|mid>\n", name);
+    fprintf(stderr, "usage: %s [-h] [-c] [nwhxyds] <wid|mid>\n", name);
     exit(1);
 }
 

--- a/mattr.c
+++ b/mattr.c
@@ -11,7 +11,7 @@ static xcb_connection_t *conn;
 
 static void
 usage(char *name) {
-    fprintf(stderr, "usage: %s [-h] [-c] [nwhxy] <wid|mid>\n", name);
+    fprintf(stderr, "usage: %s [-h] [-c] [nwhxyd] <wid|mid>\n", name);
     exit(1);
 }
 
@@ -69,6 +69,9 @@ main (int argc, char *argv[]) {
                     break;
                 case 'y':
                     printf("%d", monitor.y);
+                    break;
+                case 'd':
+                    printf("%d", monitor.num);
                     break;
 
                 // Return the ID of the window/monitor that's passed as the

--- a/util.h
+++ b/util.h
@@ -1,6 +1,7 @@
 typedef struct monitor_t {
     char *name;
     int x, y, width, height, active, connected, primary;
+    int num;
 } monitor_t;
 
 xcb_visualid_t get_visual (void);


### PR DESCRIPTION
Use `d` to return the screen number that xrandr outputs when invoked
with --listmonitors.

Upon inspection of xrandr's code
(https://cgit.freedesktop.org/xorg/app/xrandr/tree/xrandr.c#n4041) the
screen number is taken from the order in which X returns screens.

Based on #6 